### PR TITLE
fix: Add support for inline <code> tags in HTML to Markdown conversion

### DIFF
--- a/url_to_markdown_formatters.js
+++ b/url_to_markdown_formatters.js
@@ -18,7 +18,7 @@ module.exports = {
 	},
 	format_codeblocks: function (html, replacements) {
 		const start = replacements.length;
-		const codeblocks = html.match(/(<pre[^>]*>(?:.|\n)*?<\/pre>)/gi);
+		const codeblocks = html.match(/(<pre[^>]*>(?:.|\n)*?<\/pre>)|(<code[^>]*>(?:.|\n)*?<\/code>)/gi);
 		if (codeblocks) {
 			for (let c=0;c<codeblocks.length;c++) {
 				const codeblock = codeblocks[c];
@@ -27,7 +27,9 @@ module.exports = {
 				filtered = filtered.replace(/<p>/g, "\n");
 				filtered = filtered.replace(/<\/?[^>]+(>|$)/g, "");		
 				filtered = htmlEntities.decode(filtered);
-				let markdown = "```\n"+filtered+"\n```\n";
+				let markdown = codeblock.startsWith('<pre') ? 
+					"```\n"+filtered+"\n```\n" : 
+					"`"+filtered.trim()+"`";
 				let placeholder = "urltomarkdowncodeblockplaceholder"+c+Math.random();
 				replacements[start+c] = { placeholder: placeholder, replacement: markdown};
 				html = html.replace(codeblock, "<p>"+placeholder+"</p>");


### PR DESCRIPTION
## Problem
The current HTML to Markdown converter only properly handles `<pre>` tags for code blocks, but fails to correctly capture and convert inline `<code>` tags.

## Solution
Updated the `format_codeblocks` function to:
- Capture both `<pre>` and `<code>` tags using an improved regex pattern
- Format `<pre>` content as block code with triple backticks (```)
- Format `<code>` content as inline code with single backticks (`)

## Changes
- Modified regex pattern in `format_codeblocks()` to match both tag types
- Added conditional formatting based on the tag type
- Maintained existing placeholder system for replacements

## Testing (To do)
The changes ensure:
- Block code (`<pre>`) continues to work as before
- Inline code (`<code>`) is now properly converted
- Existing functionality remains intact

Thanks.